### PR TITLE
Bug 884073 - Change jobvite link to protocol relative

### DIFF
--- a/careers/settings/base.py
+++ b/careers/settings/base.py
@@ -64,4 +64,4 @@ HMAC_KEYS = {
 }
 
 # Jobvite URI
-JOBVITE_URI = 'http://www.jobvite.com/CompanyJobs/Xml.aspx?c=qpX9Vfwa'
+JOBVITE_URI = '//www.jobvite.com/CompanyJobs/Xml.aspx?c=qpX9Vfwa'


### PR DESCRIPTION
Remove http: to allow the site to be relative since careers is forced https already. We could change it to https, but it seems like protocol relative would work too.
