### PR TITLE
Fix Bug 884073: Make RSS Feed HTTPS. Does not change apply URL.

### DIFF
--- a/careers/settings/base.py
+++ b/careers/settings/base.py
@@ -58,4 +58,4 @@ NOSE_ARGS = ['--logging-clear-handlers', '--logging-filter=-factory,-south']
 ##############################################################################
 
 # URI of Jobvite job feed.
-JOBVITE_URI = 'http://www.jobvite.com/CompanyJobs/Xml.aspx?c=qpX9Vfwa'
+JOBVITE_URI = 'https://www.jobvite.com/CompanyJobs/Xml.aspx?c=qpX9Vfwa'


### PR DESCRIPTION
The bug mentions the apply url. This comes from django-jobvite and is a pass through from the rss feed.

So the rss feed has http.

Not sure if we can change that in admin. Regardless thats a diff issue.

Note I did this PR to close out a very old PR that chris had submitted.
