### PR TITLE
Remove erroneous vendor.pth entry

### DIFF
--- a/vendor-local/vendor.pth
+++ b/vendor-local/vendor.pth
@@ -1,2 +1,1 @@
 src/django-jobvite
-src/south


### PR DESCRIPTION
South is under vendor-local/lib/python, not vendor-local/src
