### PR TITLE
Fix Bug 931094 - Listings Link Colours

### DIFF
--- a/careers/careers/static/css/listings.css
+++ b/careers/careers/static/css/listings.css
@@ -92,7 +92,7 @@
         padding-left: 0;
     }
 
-.js-enabled #listings-positions a {
+.moz-no-touch #listings-positions a {
     color: #4d4e53;
 }
     .js-enabled #listings-positions a:hover,


### PR DESCRIPTION
Changed the line that makes listing results grey to only affect non-touch, javascript enabled devices.
