### PR TITLE
[bug 965976] Follow up, Modernizr should be available for IE8

### DIFF
--- a/careers/base/templates/base.html
+++ b/careers/base/templates/base.html
@@ -58,7 +58,7 @@
 
     {# js #}
     {% block site_js %}
-      {{ js('jquery') }}
+      {{ js('global') }}
       {{ js('google_analytics_events') }}
       <!--[if gt IE 8]> <!-- -->
       {{ js('common') }}

--- a/careers/settings/base.py
+++ b/careers/settings/base.py
@@ -72,12 +72,12 @@ MINIFY_BUNDLES = {
         ),
     },
     'js': {
-        'jquery': (
+        'global': (
             'js/libs/jquery-1.7.1.min.js',
             'js/libs/waypoints.min.js',
+            'js/libs/modernizr.custom.96716.js',
         ),
         'common': (
-            'js/libs/modernizr.custom.96716.js',
             'js/libs/video-js/video.dev.js',
             'js/base.js',
         ),


### PR DESCRIPTION
Followup to PR #99 - Modernizr should also be available for IE8 on listings page. Just occured to me after clicking the green button, snap.
