### PR TITLE
Corrected error in grammar - "have" to "our".

### DIFF
--- a/careers/university/templates/university/index.html
+++ b/careers/university/templates/university/index.html
@@ -101,7 +101,7 @@
       <div class="know-box">
         <h3><strong>Where</strong> will I be?</h3>
         <p>
-          We host interns at have several offices around the world: Mountain View, San Francisco, Toronto and Paris. Your internship location will be based on the location of your team and/or your mentor, with whom you'll work closely.
+          We host interns at our several offices around the world: Mountain View, San Francisco, Toronto and Paris. Your internship location will be based on the location of your team and/or your mentor, with whom you'll work closely.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Changed "We host interns at have several offices around the world..." to "We host interns at our several offices around the world...". Grammatically, have doesn't fit. I guessed "our" might be the best to replace.
