### PR TITLE
[fix 941829] Homepage CTAs link to /university

### DIFF
--- a/careers/careers/templates/careers/home.html
+++ b/careers/careers/templates/careers/home.html
@@ -26,7 +26,7 @@
   <p class="splash-subhead">Want to join in?</p>
   <div class="cta-strip">
     <a class="cta ga-career-banner-listings" href="{{ url('careers.listings') }}">View our current openings</a>
-    <a class="cta ga-career-banner-internship" href="{{ url('careers.listings')|urlparams(position_type='Intern') }}">Apply for an internship</a>
+    <a class="cta ga-career-banner-internship" href="{{ url('university.index') }}">Apply for an internship</a>
     <a class="cta ga-career-banner-volunteer" href="https://www.mozilla.org/contribute/">Become a volunteer</a>
   </div>
   <div class="splash-credo">
@@ -186,7 +186,7 @@
         </blockquote>
         <figcaption>Tanay Delima</figcaption>
       </figure>
-      <a class="cta" href="{{ url('careers.listings')|urlparams(position_type='Intern') }}">View Open Positions</a>
+      <a class="cta" href="{{ url('university.index') }}">Find out more</a>
     </div>
   </article>
 </section>
@@ -453,7 +453,7 @@
   </div>
   <div class="cta-strip">
     <a class="cta ga-career-banner-listings-bottom" href="{{ url('careers.listings') }}">View our current openings</a>
-    <a class="cta ga-career-banner-internship-bottom" href="{{ url('careers.listings')|urlparams(position_type='Intern') }}">Apply for an internship</a>
+    <a class="cta ga-career-banner-internship-bottom" href="{{ url('university.index') }}">Apply for an internship</a>
     <a class="cta ga-career-banner-volunteer-bottom" href="https://www.mozilla.org/contribute/">Become a volunteer</a>
   </div>
 </section>


### PR DESCRIPTION
Top & bottom "Apply for intership" CTAs on the homepage and "Find out
more" (old "View Open Position", now renamed) CTA on each team
introduction now link to /university.
