### PR TITLE
fix bug 932108 - Tabzilla formatting issues

### DIFF
--- a/careers/base/static/css/base.css
+++ b/careers/base/static/css/base.css
@@ -201,6 +201,7 @@ figure {
 
 #tabzilla-panel h2 {
     letter-spacing: -1px;
+    line-height: 100%;
 }
 
 #q {


### PR DESCRIPTION
Tabzilla is now identical to the Tabzilla of www.mozilla.org. Some `line-height` was overwritten by css from the page, together with a `font-family`.
