### PR TITLE
s/#team-building/#teams/g

### DIFF
--- a/careers/careers/static/css/careers.css
+++ b/careers/careers/static/css/careers.css
@@ -763,8 +763,8 @@
             z-index: -1;
         }
 
-        .js-disabled .team-building:before,
-        .team-bg.team-building:before { content: url(/static/img/teams/building.jpg); }
+        .js-disabled .teams:before,
+        .team-bg.teams:before { content: url(/static/img/teams/building.jpg); }
         .js-disabled .team-operations:before,
         .team-bg.team-operations:before { content: url(/static/img/teams/operations.jpg); }
         .js-disabled .team-people:before,

--- a/careers/careers/templates/careers/home.html
+++ b/careers/careers/templates/careers/home.html
@@ -58,7 +58,7 @@
 
       <ul class="teams-nav">
         <li class="teams-hex hex-building">
-          <a href="#team-building" class="nosmoothscroll">
+          <a href="#teams" class="nosmoothscroll">
             <strong>Building &amp; Designing</strong>
             Big kids playing with pixels and code.
           </a>
@@ -100,7 +100,7 @@
     </div>
   </div>
 
-  <article id="team-building" class="teams-team team-building team-bg">
+  <article id="teams" class="teams-team team-building team-bg">
     <div class="team-contain">
       <h3 class="team-head">Building &amp; Designing</h3>
       <p>


### PR DESCRIPTION
Fixes issue with linking to `#team-building` by replacing all instances of it with `#teams` which doesn't seem to exhibit the same behaviour.

Not sure if this will fly since if someone has linked to `#team-building` directly from somewhere else on the web that person will not be smooth scrolled down to the teams section. If this is a requirement for fixing this bug I can probably mix in something to this PR to make sure that we are backwards compatible to this link. 

[Bugzilla bug 933991](https://bugzilla.mozilla.org/show_bug.cgi?id=933991).
