### PR TITLE
Fix various puppet errors in vagrant provision.

### DIFF
--- a/puppet/manifests/classes/playdoh.pp
+++ b/puppet/manifests/classes/playdoh.pp
@@ -3,16 +3,16 @@
 
 # TODO: Make this rely on things that are not straight-up exec.
 class playdoh {
-    file { "$PROJ_DIR/settings/local.py":
+    file { "$PROJ_DIR/careers/settings/local.py":
         ensure => file,
-        source => "$PROJ_DIR/settings/local.py-dist",
+        source => "$PROJ_DIR/careers/settings/local.py-dist",
         replace => false;
     }
 
     exec { "create_mysql_database":
         command => "mysqladmin -uroot create $DB_NAME",
         unless  => "mysql -uroot -B --skip-column-names -e 'show databases' | /bin/grep '$DB_NAME'",
-        require => File["$PROJ_DIR/settings/local.py"]
+        require => File["$PROJ_DIR/careers/settings/local.py"]
     }
 
     exec { "grant_mysql_database":
@@ -32,7 +32,7 @@ class playdoh {
         command => "python ./manage.py migrate",
         require => [
             Service["mysql"],
-            Package["python2.6-dev", "libapache2-mod-wsgi", "python-wsgi-intercept" ],
+            Package["python2.7-dev", "libapache2-mod-wsgi", "python-wsgi-intercept" ],
             Exec["syncdb"]
         ];
     }

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -3,14 +3,14 @@ class python {
     case $operatingsystem {
         centos: {
             package {
-                ["python26-devel", "python26-libs", "python26-distribute", "python26-mod_wsgi"]:
+                ["python27-devel", "python27-libs", "python27-distribute", "python27-mod_wsgi"]:
                     ensure => installed;
             }
 
             exec { "pip-install":
                 command => "easy_install -U pip",
                 creates => "pip",
-                require => Package["python26-devel", "python26-distribute"]
+                require => Package["python27-devel", "python27-distribute"]
             }
 
             exec { "pip-install-compiled":
@@ -21,7 +21,7 @@ class python {
 
         ubuntu: {
             package {
-                ["python2.6-dev", "python2.6", "libapache2-mod-wsgi", "python-wsgi-intercept", "python-pip"]:
+                ["python2.7-dev", "python2.7", "libapache2-mod-wsgi", "python-wsgi-intercept", "python-pip"]:
                     ensure => installed;
             }
 

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -7,7 +7,7 @@ $PROJ_DIR = "/home/vagrant/project"
 
 # You can make these less generic if you like, but these are box-specific
 # so it's not required.
-$DB_NAME = "lumbergh_app"
+$DB_NAME = "lumbergh"
 $DB_USER = "root"
 
 Exec {


### PR DESCRIPTION
When doing #119 I noticed that the puppet apply failed while trying to install python2.6. Probably because I update the vagrant OS to be ubuntu precise rather then lucid.

But that should be fixed with these changes.
