### PR TITLE
Fix bug 1101783: Clicking an open position link while pressing [ctrl] sh...

### DIFF
--- a/careers/careers/static/js/listings.js
+++ b/careers/careers/static/js/listings.js
@@ -36,7 +36,7 @@
 
     // go to the position details page for the job position clicked
     function listingGoToPosition(e) {
-        if(e.target.nodeName !== 'A') {
+        if (e.target.tagName !== 'A') {
             var listingsTarget = $(e.target);
             var listingsRow = listingsTarget.closest('.position');
             var listingsLocation = listingsRow.find('.title a').prop('href');


### PR DESCRIPTION
...ouldn't open the position details in the current tab.

https://bugzilla.mozilla.org/show_bug.cgi?id=1101783
- Clicking the _link_ will allow the browser to redirect the user by itself.
- Clicking anywhere in the table's row will redirect the user via JavaScript.
