### PR TITLE
[fix #225] Update bleach allowed tags to current greenhouse spec.

### DIFF
--- a/careers/careers/management/commands/sync_greenhouse.py
+++ b/careers/careers/management/commands/sync_greenhouse.py
@@ -13,6 +13,11 @@ from careers.careers.models import Position
 GREENHOUSE_URL = 'https://api.greenhouse.io/v1/boards/{}/jobs/?content=true'
 H = HTMLParser.HTMLParser()
 
+ALLOWED_TAGS = [
+    u'a', u'abbr', u'acronym', u'b', u'blockquote', u'code', u'em',
+    u'i', u'li', u'ol', u'ul', u'p', u'br', 'h4',
+]
+
 
 class Command(BaseCommand):
     args = '(no args)'
@@ -57,7 +62,7 @@ class Command(BaseCommand):
 
             description = H.unescape(job.get('content', ''))
             description = bleach.clean(description,
-                                       tags=bleach.ALLOWED_TAGS + ['p', 'br'],
+                                       tags=ALLOWED_TAGS,
                                        strip=True)
 
             for metadata in job.get('metadata', []):

--- a/careers/careers/static/css/position.css
+++ b/careers/careers/static/css/position.css
@@ -27,22 +27,30 @@
     padding: 10px 0 0 0;
 }
 
-    .job-post-details > dt {
-        font-family: 'Open Sans Light',sans-serif;
-        font-size: 13px;
-        line-height: 18px;
-        text-transform: uppercase;
-    }
+.job-post-details > dt {
+    font-family: 'Open Sans Light',sans-serif;
+    font-size: 13px;
+    line-height: 18px;
+    text-transform: uppercase;
+}
 
-    .job-post-details > dd {
-        margin-left: 0;
-        margin-bottom: 10px;
-        line-height: 18px;
-    }
+.job-post-details > dd {
+    margin-left: 0;
+    margin-bottom: 10px;
+    line-height: 18px;
+}
 
 .job-post-description {
     margin: 20px 0;
 }
+
+
+.job-post-description h4 {
+    font-weight: bold;
+    font-size: 16px;
+    line-height: 1.5;
+}
+
 
 .job-related {
     display: none;

--- a/careers/careers/tests/test_commands.py
+++ b/careers/careers/tests/test_commands.py
@@ -23,7 +23,7 @@ class SyncGreenhouseTests(TestCase):
                     'title': 'Web Fox',
                     'updated_at': '2016-07-25T14:45:57-04:00',
                     'absolute_url': 'http://example.com/foo',
-                    'content': '&lt;strong&gt;foo&lt;/strong&gt; bar',
+                    'content': '&lt;h2&gt;foo&lt;/h2&gt; bar',
                     "metadata": [
                         {
                             "id": 69450,
@@ -67,7 +67,7 @@ class SyncGreenhouseTests(TestCase):
         self.assertEqual(position.apply_url, 'http://example.com/foo')
         self.assertEqual(position.source, 'gh')
         self.assertEqual(position.position_type, 'Full-time')
-        self.assertEqual(position.description, '<strong>foo</strong> bar')
+        self.assertEqual(position.description, '<h4>foo</h4> bar')
 
     def test_job_removal(self):
         PositionFactory.create(job_id='xxx')


### PR DESCRIPTION
Link to current spec https://docs.google.com/document/d/1rHN7L_DYN59TdPkH1HPfpaMIbMbMjYfOa8GSaaEAq2A/

This practically allows for `h4`. The current greenhouse spec abuses h4 to get larger font size and bold font weight so... i adapted to that.