### PR TITLE
set cache-control on aws sync

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ deploy stage:
   only:
     refs:
     - master
+    - dp_cache_tweak
   script: ./bin/ci-mirror.sh
 
 deploy prod:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ deploy stage:
   only:
     refs:
     - master
-    - dp_cache_tweak
+    - dp_set_cache_control
   script: ./bin/ci-mirror.sh
 
 deploy prod:

--- a/bin/Dockerfile
+++ b/bin/Dockerfile
@@ -24,4 +24,4 @@ RUN pip install awscli
 
 COPY --chown=webdev . /app
 USER webdev
-CMD ./bin/mirror.sh && aws s3 sync ./_site ${BUCKET_PATH} --acl public-read --delete && curl ${DMS}
+CMD ./bin/mirror-to-s3.sh

--- a/bin/mirror-to-s3.sh
+++ b/bin/mirror-to-s3.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-echo $(PWD)
+
 ./bin/mirror.sh 
 
 aws s3 sync ./_site ${BUCKET_PATH} \

--- a/bin/mirror-to-s3.sh
+++ b/bin/mirror-to-s3.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+echo $(PWD)
+./bin/mirror.sh 
+
+aws s3 sync ./_site ${BUCKET_PATH} \
+    --acl public-read \
+    --cache-control "max-age=315360000, public, immutable"  \
+    --delete
+
+aws s3 cp ./_site/listings/index.html ${BUCKET_PATH}/listings/index.html \
+    --acl public-read \
+    --cache-control "max-age=1800, public" \
+
+curl ${DMS}
+

--- a/bin/mirror-to-s3.sh
+++ b/bin/mirror-to-s3.sh
@@ -9,7 +9,7 @@ aws s3 sync ./_site ${BUCKET_PATH} \
 
 aws s3 cp ./_site/listings/index.html ${BUCKET_PATH}/listings/index.html \
     --acl public-read \
-    --cache-control "max-age=1800, public" \
+    --cache-control "max-age=1800, public"
 
 curl ${DMS}
 


### PR DESCRIPTION
- before merge, remove `dp_set_cache_control` from gitlab-ci.yaml
- applied to stage:
  - https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fcareers.allizom.org\
- I disabled public CI for this repo in Gitlab, but members of mozmeao can see the build [here](https://gitlab.com/mozmeao/lumbergh/pipelines/55427462). If you're not in mozmeao, you'll get a 404 (try it in a private window)