### PR TITLE
[Fix #418] Upgrade to Debian Buster / Python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim-stretch
+FROM python:3-slim-buster
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
Wait for docker python buster images to get released