### PR TITLE
[fix #448] Fix robots.txt for production, part 2.

### DIFF
--- a/bin/ci-mirror.sh
+++ b/bin/ci-mirror.sh
@@ -13,4 +13,5 @@ docker run \
       -e DMS \
       -e DMS_BLOG_FETCH \
       -e CI_COMMIT_SHA \
+      -e CI_COMMIT_REF_NAME \
       ${IMAGE}


### PR DESCRIPTION
- Pass CI_COMMIT_REF_NAME ENV var through to Docker

follow-up to #449.