### PR TITLE
[fix #473] link Internships nav item directly to postings.

### DIFF
--- a/careers/base/static/js/base.js
+++ b/careers/base/static/js/base.js
@@ -3,18 +3,4 @@
 
     Mzp.Navigation.init();
     Mzp.Menu.init();
-
-    // wire up modal when clicking "Internships" in nav (temporary)
-    var content = document.getElementById('internships-modal');
-
-    var link = document.getElementById('ga-nav-internships');
-
-    link.addEventListener('click', function (e) {
-        e.preventDefault();
-        Mzp.Modal.createModal(e.target, content, {
-            title: 'Please check back',
-            closeText: 'Close modal'
-        });
-    }, false);
-
 })(window.Mzp);

--- a/careers/base/templates/base.jinja
+++ b/careers/base/templates/base.jinja
@@ -66,7 +66,6 @@
       <script src="{{ static('js/ga_event-tracking.js') }}"></script>
       <script src="{{ static('js/protocol/protocol-navigation.min.js') }}"></script>
       <script src="{{ static('js/protocol/protocol-menu.min.js') }}"></script>
-      <script src="{{ static('js/protocol/protocol-modal.min.js') }}"></script>
       <script src="{{ static('js/base.js') }}"></script>
     {% endblock %}
 

--- a/careers/base/templates/base/header.jinja
+++ b/careers/base/templates/base/header.jinja
@@ -31,13 +31,3 @@
     </div>
   </div>
 </div>
-
-<div class="mzp-u-modal-content" id="internships-modal">
-  <p>
-    We’ve finished our internship hiring for Summer 2019, but please check back with us
-    soon! We will begin accepting applications in September 2019 for Summer 2020
-    internships. If you’re still interested in contributing to Mozilla now, we’d love
-    for you to <a href="https://www.mozilla.org/contribute/">get involved</a>.
-  </p>
-</div>
-

--- a/careers/careers/static/js/listings.js
+++ b/careers/careers/static/js/listings.js
@@ -10,8 +10,10 @@
     */
     function propogateQueryParamsToSelects() {
         var i;
+        var j;
         var keyVal;
         var keyVals;
+        var match;
         var qs = window.location.search;
         var select;
         var val;
@@ -32,10 +34,22 @@
 
                 // make sure the key is valid, then update the associated select box
                 if (select) {
-                    // undo the jQuery param string augmentation
                     // (decodeURIComponent does not change '+' to ' ', hence the replace call)
                     val = decodeURIComponent(keyVal[1]).replace(/\+/gi, ' ');
-                    select.value = val;
+
+                    // make sure select has an option matching the proposed value
+                    // this ensures the select box doesn't get set to an empty value if
+                    // e.g. there are no Intern positions available
+                    for (j = 0; j < select.options.length; j++) {
+                        if (select.options[j].value === val) {
+                            match = true;
+                            break;
+                        }
+                    }
+
+                    if (match) {
+                        select.value = val;
+                    }
                 }
             }
         }


### PR DESCRIPTION
the "Internships" link in the nav already had an `href` set to intern listings. this PR removes the JS that intercepted that link click and displayed the modal.

also adds a little robustness to the JS to make sure passing a position type in the query string that isn't present in the select box (like when Intern positions go away for the year) will not result in the select box being set to an empty value. (can test with manually changing the `position_type` param in the querystring to something non-existent, e.g. "Bowler".)