### PR TITLE
[Fix #515] Faster S3 syncs with rclone.

### DIFF
--- a/bin/rclone.conf
+++ b/bin/rclone.conf
@@ -1,0 +1,8 @@
+[s3]
+type = s3
+provider = AWS
+env_auth = true
+acl = public-read
+storage_class = STANDARD
+region = us-west-2
+transfers = 8

--- a/bin/sync.sh
+++ b/bin/sync.sh
@@ -2,28 +2,38 @@
 
 # `-f` escapes `*`
 set -xf
+BUCKET_PATH=${BUCKET_PATH:-s3://mozilla-careers-stage}
+BUCKET_NAME=${BUCKET_PATH:5}
 
-echo "Before Syncs"
-echo $(date +%s)
+# Set to true to update Cache-Control metadata for all static files.
+GLOBAL_SET_METADATA=${GLOBAL_SET_METADATA:-false}
 
 # Sync static assets first, before uploading other files that reference them.
-# Set long live cache headers.
-aws s3 sync ./_site ${BUCKET_PATH} \
-    --exclude "*" \
-    $(jq .paths[] static/staticfiles.json | xargs -I {} echo -n "--include static/{}* ") \
-    --cache-control "max-age=315360000,public,immutable" \
-    --acl public-read \
-    --delete
+# Set long live cache headers using `aws s3api` only to files that changed.
+CHANGED_FILES=$(\
+    ./bin/rclone --config ./bin/rclone.conf --no-update-modtime -v -P \
+                 $(jq .paths[] static/staticfiles.json | xargs -I {} echo -n "--include static/{} ") \
+                 sync ./_site ${BUCKET_PATH} 2>&1 | grep "Copied" | cut -d ":" -f 4)
 
-echo "After Static Sync, before Non-static Sync"
-echo $(date +%s)
+
+if [ ${GLOBAL_SET_METADATA} = true ];
+then
+    CHANGED_FILES=$(jq .paths[] static/staticfiles.json -r | xargs -I {}  echo "static/{}")
+fi
+
+for file in ${CHANGED_FILES};
+do
+    aws s3api copy-object \
+        --acl public-read \
+        --copy-source ${BUCKET_NAME}/${file} \
+        --bucket  ${BUCKET_NAME} \
+        --key ${file} \
+        --metadata-directive REPLACE \
+        --cache-control "max-age=315360000,public,immutable"
+done
+
 
 # Sync the rest of the files.
-aws s3 sync ./_site ${BUCKET_PATH} \
-    --include "*" \
-    $(jq .paths[] static/staticfiles.json | xargs -I {} echo -n "--exclude static/{}* ") \
-    --acl public-read \
-    --delete
-
-echo "After Static Syncs"
-echo $(date +%s)
+./bin/rclone --config ./bin/rclone.conf \
+       $(jq .paths[] static/staticfiles.json | xargs -I {} echo -n "--exclude static/{} ") \
+       sync ./_site ${BUCKET_PATH}


### PR DESCRIPTION
[Rclone](https://rclone.org/) is a wonderful tool and apparently much faster to sync compared to `aws s3 sync`. Doesn't set metadata though, so I still use `aws` tool and `s3api` to set `Cache-Control` headers.

A [full, clean sync](https://gitlab.com/mozmeao/lumbergh/-/jobs/401131902) is now about 5 minutes and a [re-sync](https://gitlab.com/mozmeao/lumbergh/-/jobs/401140385) less than 30 seconds

![image](https://user-images.githubusercontent.com/584352/72259540-6da78980-3619-11ea-89cd-28eaf572097d.png)
 