### PR TITLE
Preserve metadata on S3 when setting Cache-Control

### DIFF
--- a/bin/sync.sh
+++ b/bin/sync.sh
@@ -23,13 +23,20 @@ fi
 
 for file in ${CHANGED_FILES};
 do
+    metadata=$(
+        aws s3api head-object \
+            --bucket ${BUCKET_NAME} \
+            --key ${file}
+             )
     aws s3api copy-object \
         --acl public-read \
         --copy-source ${BUCKET_NAME}/${file} \
         --bucket  ${BUCKET_NAME} \
         --key ${file} \
         --metadata-directive REPLACE \
-        --cache-control "max-age=315360000,public,immutable"
+        --content-type $(echo $metadata | jq .ContentType) \
+        --cache-control "max-age=315360000,public,immutable" \
+        --metadata "{\"mtime\": $(echo $metadata | jq .Metadata.mtime)}"
 done
 
 


### PR DESCRIPTION
Had to modify the metadata set command to ensure that `content-type` is preserved when we set cache-control headers. Since i was doing that i also preserved `mtime`.

This is a bit more complex than it should be, just because `aws s3api` command cannot do it by itself. 