### PR TITLE
Don't test twitter.com

### DIFF
--- a/bin/build-acceptance-tests.sh
+++ b/bin/build-acceptance-tests.sh
@@ -50,7 +50,7 @@ while read -r url; do
     then
         bad_urls+=("$url")
     fi
-done < <(sed -n 's/.*href="\(http[^"]*\).*/\1/p' index.html)
+done < <(sed -n 's/.*href="\(http[^"]*\).*/\1/p' index.html | grep -v twitter.com)
 
 # if we captured any bad urls, echo them out and return w/exit code 1
 if [ "${#bad_urls[@]}" -gt 0 ];


### PR DESCRIPTION
This is a fix for the `429 Too many requests` error we get from when acceptance tests try to test `twitter.com`

Alternatively we could test only `mozilla.(org|net|com)/*` links but I prefer that we keep testing as much as possible. Besides mozilla properties we currently link to

 - fastcompany.com
 - instagram.com
 - twitter.com

thoughts @mozmeao/meaocloud ?
