### PR TITLE
Add open graph headers

### DIFF
--- a/careers/base/templates/base.jinja
+++ b/careers/base/templates/base.jinja
@@ -1,8 +1,8 @@
+{% set default_slug = "Mozilla Careers &mdash; Feel good about your work again" %}
 <!DOCTYPE html>
 <html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js"
       data-ga-code="{{ settings.GA_ACCOUNT_CODE }}"
       data-gtm-code="{{ settings.GTM_ACCOUNT_CODE }}">
-{% set default_slug = "Mozilla Careers &mdash; Feel good about your work again" %}
   <head>
     {# meta #}
     <meta charset="UTF-8">

--- a/careers/base/templates/base.jinja
+++ b/careers/base/templates/base.jinja
@@ -2,13 +2,23 @@
 <html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js"
       data-ga-code="{{ settings.GA_ACCOUNT_CODE }}"
       data-gtm-code="{{ settings.GTM_ACCOUNT_CODE }}">
+{% set default_slug = "Mozilla Careers &mdash; Feel good about your work again" %}
   <head>
     {# meta #}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="{% block meta_description %}{% endblock %}">
-    <title>{% block page_title %}mozilla.org{% endblock %}</title>
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{ meta_title|default(default_slug, true) }}">
+    <meta property="og:description" content="{{ meta_description|default(default_slug, true) }}">
+    <meta property="og:image" content="{{ meta_image|default(static('img/hero-bg-high-res.jpg'), true) }}">
+    <meta property="og:image:alt" content="{{ meta_title|default(default_slug, true) }}">
+    <meta name="twitter:title" content="{{ meta_title|default(default_slug, true) }}">
+    <meta name="twitter:description" content="{{ meta_description|default(default_slug, true) }}">
+    <meta name="twitter:image" content="{{ meta_image|default(static('img/hero-bg-high-res.jpg'), true) }}">
+    <meta name="twitter:card" content="summary">
+    <meta name="description" content="{{ meta_description|default(default_slug, true) }}">
+    <title>{{ meta_title|default(default_slug, true) }}</title>
 
     {# css #}
     {% block site_css %}

--- a/careers/careers/templates/careers/home.jinja
+++ b/careers/careers/templates/careers/home.jinja
@@ -1,7 +1,7 @@
 {% extends "base.jinja" %}
 
-{% block meta_description %}Feel good about your work again. At Mozilla, you can pursue your future while working to protect the future of the internet for everyone, everywhere.{% endblock %}
-{% block page_title %}Mozilla Jobs &mdash; Open Positions{% endblock %}
+{% set meta_title = "Mozilla Careers &mdash; Feel good about your work again." %}
+{% set meta_description = "Mozilla Careers &mdash; Feel good about your work again. At Mozilla, you can pursue your future while working to protect the future of the internet for everyone, everywhere." %}
 
 {% block content %}
 

--- a/careers/careers/templates/careers/internships.jinja
+++ b/careers/careers/templates/careers/internships.jinja
@@ -1,7 +1,7 @@
 {% extends "base.jinja" %}
 
 {% set meta_title = "Mozilla Careers &mdash; Experience an internship at Mozilla" %}
-{% set meta_description = "Mozilla Careers &mdash; Interns at Mozilla work alongside industry leaders on meaningful projects like online privacy protection" %}
+{% set meta_description = "Mozilla Careers &mdash; Interns at Mozilla work alongside industry leaders on meaningful projects like online privacy protection." %}
 {% set meta_image = static('img/internships/team-high-res.jpg') %}
 
 {% block body_class %}internships-page{% endblock %}

--- a/careers/careers/templates/careers/internships.jinja
+++ b/careers/careers/templates/careers/internships.jinja
@@ -1,9 +1,8 @@
 {% extends "base.jinja" %}
 
-{% block page_title %}Experience an internship at Mozilla{% endblock %}
-
-{% block meta_description %}Interns at Mozilla work alongside industry leaders on meaningful projects like online
-privacy protection.{% endblock %}
+{% set meta_title = "Mozilla Careers &mdash; Experience an internship at Mozilla" %}
+{% set meta_description = "Mozilla Careers &mdash; Interns at Mozilla work alongside industry leaders on meaningful projects like online privacy protection" %}
+{% set meta_image = static('img/internships/team-high-res.jpg') %}
 
 {% block body_class %}internships-page{% endblock %}
 

--- a/careers/careers/templates/careers/listings.jinja
+++ b/careers/careers/templates/careers/listings.jinja
@@ -1,7 +1,7 @@
 {% extends "base.jinja" %}
 
 {% set meta_title = "Mozilla Careers &mdash; All open positions at Mozilla" %}
-{% set meta_description = "Mozilla Careers &mdash; We have a mighty mandate, serving hundreds of millions of people. Add a culture of exploration, and there is always a new way to learn and grow here" %}
+{% set meta_description = "Mozilla Careers &mdash; We have a mighty mandate, serving hundreds of millions of people. Add a culture of exploration, and there is always a new way to learn and grow here." %}
 {% set meta_image = static('img/hero-bg-jobs-high-res.jpg') %}
 
 {% block body_class %}listings-page{% endblock %}

--- a/careers/careers/templates/careers/listings.jinja
+++ b/careers/careers/templates/careers/listings.jinja
@@ -1,7 +1,8 @@
 {% extends "base.jinja" %}
 
-{% block meta_description %}We have a mighty mandate, serving hundreds of millions of people. Add a culture of exploration, and there is always a new way to learn and grow here.{% endblock %}
-{% block page_title %}All open positions at Mozilla{% endblock %}
+{% set meta_title = "Mozilla Careers &mdash; All open positions at Mozilla" %}
+{% set meta_description = "Mozilla Careers &mdash; We have a mighty mandate, serving hundreds of millions of people. Add a culture of exploration, and there is always a new way to learn and grow here" %}
+{% set meta_image = static('img/hero-bg-jobs-high-res.jpg') %}
 
 {% block body_class %}listings-page{% endblock %}
 

--- a/careers/careers/templates/careers/position.jinja
+++ b/careers/careers/templates/careers/position.jinja
@@ -1,7 +1,7 @@
 {% extends "base.jinja" %}
 
-{% block meta_description %}{{ meta_description|truncate(160, end='…') }}{% endblock %}
-{% block page_title %}{{ position.title }} &mdash; Mozilla Jobs &mdash; Open Positions{% endblock %}
+{% set meta_title = "Mozilla Careers &mdash; {{ position.title }} &mdash; Open Positions" %}
+{% set meta_description = "Mozilla Careers &mdash; {{ meta_description|truncate(175, end='…') }}" %}
 
 {% block body_class %}position-page{% endblock %}
 

--- a/contribute.json
+++ b/contribute.json
@@ -9,7 +9,7 @@
         "home": "https://github.com/mozmeao/lumbergh",
         "docs": "https://github.com/mozmeao/lumbergh#setup-your-environment-for-development",
         "irc": "slack:///#websites",
-        "irc-contacts": ["#websites", "giorgos", "metadave"]
+        "irc-contacts": ["#websites", "giorgos", "pmac"]
     },
     "bugs": {
         "list": "https://github.com/mozmeao/lumbergh/issues",


### PR DESCRIPTION
Resolves #453 

I've added three variables, `meta_title`, `meta_description`, and `meta_image`. These are given sensible defaults in the base template, but can be overridden in the child templates. These variables are used to set the vanilla page title and description, and also the Open Graph headers.