### PR TITLE
Remove top level internships menu item

### DIFF
--- a/careers/base/static/js/ga_event-tracking.js
+++ b/careers/base/static/js/ga_event-tracking.js
@@ -28,7 +28,6 @@
     trackClick('#ga-nav-home-logo', ['Top Navigation', 'Click', 'Home Logo']);
     trackClick('#ga-nav-life', ['Top Navigation', 'Click', 'Life At Mozilla']);
     trackClick('#ga-nav-locations', ['Top Navigation', 'Click', 'Locations']);
-    trackClick('#ga-nav-internships', ['Top Navigation', 'Click', 'Internships']);
     trackClick('#ga-nav-listing', ['Top Navigation', 'Click', 'Job Listing']);
 
     /* Listings

--- a/careers/base/templates/base/header.jinja
+++ b/careers/base/templates/base/header.jinja
@@ -19,9 +19,6 @@
                 <a href="https://blog.mozilla.org/careers/" class="mzp-c-menu-title" id="ga-nav-life" target="_blank">Life at Mozilla</a>
               </li>
               <li class="mzp-c-menu-category">
-                <a href="{{ url('careers.internships') }}" class="mzp-c-menu-title" id="ga-nav-internships">Internships</a>
-              </li>
-              <li class="mzp-c-menu-category">
                 <a href="{{ url('careers.home')|urlparams(hash='locations') }}" class="mzp-c-menu-title" id="ga-nav-locations">Locations</a>
               </li>
             </ul>


### PR DESCRIPTION
Relates to https://github.com/mozmeao/lumbergh/issues/607.

My understanding is that Mozilla is suspending the internship program until further notice. Once the program is back, this PR could be reverted.