### PR TITLE
GH-717 and new, updated privacy pdf.

### DIFF
--- a/careers/careers/templates/careers/position.jinja
+++ b/careers/careers/templates/careers/position.jinja
@@ -42,7 +42,7 @@
   <div class="c-apply-button-container">
     <a href="{{ position.apply_url }}" class="mzp-c-button">Apply for this job</a>
     <small>
-      <a rel="external" href="https://assets.mozilla.net/pdf/Mozilla_Applicant_Privacy_Notice_May_2018.pdf">Applicant Privacy Notice</a>
+      <a rel="external" href="https://assets.mozilla.net/pdf/Mozilla_Applicant_Privacy_Notice_May_2021.pdf">Applicant Privacy Notice</a>
     </small>
   </div>
 </section>

--- a/careers/careers/utils.py
+++ b/careers/careers/utils.py
@@ -5,9 +5,6 @@ def generate_position_meta_description(position):
         f'{position.position_type.lower()} {position.title} in '
     )
 
-    if len(position.location_list) > 1:
-        meta = meta + f'{", ".join(position.location_list[:-1])} and {position.location_list[-1]}'
-    else:
-        meta = meta + position.location_list[0]
+    meta = meta + position.job_locations
 
     return meta


### PR DESCRIPTION
## Description
This PR has two changes, GH-717 and an off-the-grid request to update the privacy PDF.

For GH-717, the location mapping fix that was provided was not spread to include the OG description for a position. This is what gets displayed on social shares. In order to fix this, I used the property created during the mapping fix instead of the old field.

## Issue / Bugzilla link
https://github.com/mozmeao/lumbergh/issues/717

## Testing
Manual.
