### PR TITLE
Link to 2021 version of privacy PDF and remove benefits nav item.

### DIFF
--- a/careers/base/templates/base/header.jinja
+++ b/careers/base/templates/base/header.jinja
@@ -21,9 +21,6 @@
               <li class="mzp-c-menu-category">
                 <a href="{{ url('careers.home')|urlparams(hash='locations') }}" class="mzp-c-menu-title" id="ga-nav-locations">Locations</a>
               </li>
-              <li class="mzp-c-menu-category">
-                <a href="{{ url('careers.benefits') }}" class="mzp-c-menu-title" id="ga-nav-benefits">Benefits</a>
-              </li>
             </ul>
           </nav>
         </div>

--- a/careers/careers/templates/careers/position.jinja
+++ b/careers/careers/templates/careers/position.jinja
@@ -42,7 +42,7 @@
   <div class="c-apply-button-container">
     <a href="{{ position.apply_url }}" class="mzp-c-button">Apply for this job</a>
     <small>
-      <a rel="external" href="https://assets.mozilla.net/pdf/Mozilla_Applicant_Privacy_Notice_May_2018.pdf">Applicant Privacy Notice</a>
+      <a rel="external" href="https://assets.mozilla.net/pdf/Mozilla_Applicant_Privacy_Notice_May_2021.pdf">Applicant Privacy Notice</a>
     </small>
   </div>
 </section>


### PR DESCRIPTION
## Description
The current site links to a 2018 privacy doc. This updates that link to pint to a new 2021 version. As a precaution, I also removed the benefits link from the header that made its way to master on a prior merge. That link should not go live. The task to create a benefits page has been postponed and sent back to planning.

## Issue / Bugzilla link
GH-753

## Testing
Manual.