### PR TITLE
Skip testing foundation.m.o during CI

### DIFF
--- a/bin/build-acceptance-tests.sh
+++ b/bin/build-acceptance-tests.sh
@@ -50,7 +50,7 @@ while read -r url; do
     then
         bad_urls+=("$url")
     fi
-done < <(sed -n 's/.*href="\(http[^"]*\).*/\1/p' index.html | grep -v twitter.com)
+done < <(sed -n 's/.*href="\(http[^"]*\).*/\1/p' index.html | grep -v twitter.com | grep -v foundation.mozilla.org)
 
 # if we captured any bad urls, echo them out and return w/exit code 1
 if [ "${#bad_urls[@]}" -gt 0 ];


### PR DESCRIPTION
The deployment CI script tests all URLs found in index.html before
publishing, but the foundation.mozilla.org site rejects bot traffic.
This test doesn't provide much value, so skipping it is the best option.
