### PR TITLE
remove position column from job lists

### DIFF
--- a/careers/careers/static/css/careers-new.css
+++ b/careers/careers/static/css/careers-new.css
@@ -322,15 +322,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/. */
     }
 
     .title {
-        width: 35%;
+        width: 50%;
     }
 
     .location {
         width: 25%;
-    }
-
-    .type {
-        width: 15%;
     }
 
     .name {

--- a/careers/careers/templates/careers/listings.jinja
+++ b/careers/careers/templates/careers/listings.jinja
@@ -46,7 +46,6 @@
       <tr>
         <th class="title" scope="col"><h4>Job Title</h4></th>
         <th class="location" scope="col"><h4>Location</h4></th>
-        <th class="type" scope="col"><h4>Position</h4></th>
         <th class="name" scope="col"><h4>Team</h4></th>
       </tr>
     </thead>
@@ -58,7 +57,6 @@
           data-location="{{ position.location }},">
         <td class="title"><a href="{{ position.get_absolute_url() }}">{{ position.title }}</a></td>
         <td class="location">{{ position.job_locations }}</td>
-        <td class="type">{{ position.position_type }}</td>
         <td class="name">{{ position.department }}</td>
       </tr>
     {% endfor %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 services:
   web:
     build: .
-    user: ${UID:-webdev}
+      #user: ${UID:-webdev}
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
The `position` column is deprecated and was requested to be removed from the site. 
Also tweak docker-compose.yml to work on OSX.  